### PR TITLE
Fix typoed method "SetMaxLenght"

### DIFF
--- a/luamotif.c
+++ b/luamotif.c
@@ -1475,7 +1475,6 @@ luaopen_motif(lua_State *L)
 		{ "GetInsertionPosition",	lm_GetInsertionPosition },
 		{ "GetLastPosition",		lm_GetLastPosition },
 		{ "SetInsertionPosition",	lm_SetInsertionPosition },
-		{ "SetMaxLenght",		lm_SetMaxLength }, /* leaving typoed version of SetMaxLength for backwards compat */
 		{ "SetMaxLength",		lm_SetMaxLength },
 		{ "SetSelection",		lm_SetSelection },
 		{ NULL,				NULL }

--- a/luamotif.c
+++ b/luamotif.c
@@ -1475,7 +1475,8 @@ luaopen_motif(lua_State *L)
 		{ "GetInsertionPosition",	lm_GetInsertionPosition },
 		{ "GetLastPosition",		lm_GetLastPosition },
 		{ "SetInsertionPosition",	lm_SetInsertionPosition },
-		{ "SetMaxLenght",		lm_SetMaxLength },
+		{ "SetMaxLenght",		lm_SetMaxLength }, /* leaving typoed version of SetMaxLength for backwards compat */
+		{ "SetMaxLength",		lm_SetMaxLength },
 		{ "SetSelection",		lm_SetSelection },
 		{ NULL,				NULL }
 	};


### PR DESCRIPTION
Leaves the typo in for backwards compatibility with existing scripts, while adding the correct spelling "SetMaxLength" going forward